### PR TITLE
Declare compatibility with V2 authorization extension API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 
 apply from: 'plugin-common.gradle'
 
-project.ext.pluginVersion = '1.1.0'
+project.ext.pluginVersion = '1.1.1'
 project.ext.fullVersion = project.distVersion ? "${project.pluginVersion}-${project.distVersion}" : project.pluginVersion
 
 version = project.fullVersion

--- a/src/main/java/cd/go/authorization/keycloak/Constants.java
+++ b/src/main/java/cd/go/authorization/keycloak/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
     String EXTENSION_TYPE = "authorization";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "1.0";
+    String API_VERSION = "2.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));


### PR DESCRIPTION
Please see https://github.com/klinux/gocd-keycloak-oauth-authorization-plugin/issues/6

Since you seem to be maintaining a fork due to the plugin abandonment upstream, this change should address https://github.com/klinux/gocd-keycloak-oauth-authorization-plugin/issues/6 to ensure the plugin keeps working with GoCD `23.2.0`+.

Should also work on versions back to GoCD `19.3.0`, but the plugin already declares it requires `20.3.0` so this shouldn't be a concern.